### PR TITLE
chore: fix typos and ignore `.idea` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 dist
 node_modules
 *.log
+.idea

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In the meantime, this module allows easier opting-in process:
 
 ## Usage
 
-Install `nuxt-postcss8` as as `devDependency`:
+Install `nuxt-postcss8` as `devDependency`:
 
 ```sh
 yarn add --dev nuxt-postcss8
@@ -33,7 +33,7 @@ export default {
 
 ### For module authors
 
-If you have a nuxt module that requires postcss@8, install `postcss@8` and `nuxt-postcss8` as as `dependency`:
+If you have a nuxt module that requires postcss@8, install `postcss@8` and `nuxt-postcss8` as `dependency`:
 
 ```sh
 yarn add postcss@8 nuxt-postcss8

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Since [nuxt@2.15](https://github.com/nuxt/nuxt.js/releases/tag/v2.15.0) nuxt supports opting-in to use postcss@8 (via [nuxt/nuxt.js#8546](https://github.com/nuxt/nuxt.js/pull/8546)).
 
-To avoid brekaing changes, default upgrade is pending for [csstools/postcss-preset-env#191](https://github.com/csstools/postcss-preset-env/issues/191) (see [nuxt/nuxt.js#8087](https://github.com/nuxt/nuxt.js/issues/8087) and [nuxt/nuxt.js#8408](https://github.com/nuxt/nuxt.js/pull/8408))
+To avoid breaking changes, default upgrade is pending for [csstools/postcss-preset-env#191](https://github.com/csstools/postcss-preset-env/issues/191) (see [nuxt/nuxt.js#8087](https://github.com/nuxt/nuxt.js/issues/8087) and [nuxt/nuxt.js#8408](https://github.com/nuxt/nuxt.js/pull/8408))
 
 In the meantime, this module allows easier opting-in process:
 


### PR DESCRIPTION
Added .idea folder (WebStorm) to gitignore.
Fixed brekaing typo.
Removed repeated words.